### PR TITLE
travis: benchmark PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ go:
 
 script:
   - go test -v ./...
+after_success:
+  - bash .travis/benchmark-pr.sh

--- a/.travis/benchmark-pr.sh
+++ b/.travis/benchmark-pr.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+set -e
+
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+then
+    echo "not a pull request"
+    exit
+fi
+
+COMMITTER=$(echo ${TRAVIS_PULL_REQUEST_SLUG} | grep -o '^[^/]*')
+SLUG=${TRAVIS_REPO_SLUG}
+COMMIT=${TRAVIS_PULL_REQUEST_SHA}
+
+PROBLEM_DIR=$(git show --name-status $COMMIT | tail -n 1 | grep -oP '\S*(?=/)')
+if [[ -z "$PROBLEM_DIR" || "${PROBLEM_DIR:0:1}" == "." ]]
+then
+    echo "not a problem pull request"
+    exit
+fi
+
+SOLUTION_LINK=$(echo "https://github.com/$SLUG/blob/$COMMIT/$PROBLEM_DIR/$PROBLEM_DIR.go")
+
+cd $PROBLEM_DIR
+
+echo "PR:        $TRAVIS_PULL_REQUEST"
+echo "opened by: $COMMITTER"
+echo "problem:   $PROBLEM_DIR"
+echo ""
+echo "below follows github markdown:"
+echo ""
+
+# markdown
+echo "---"
+echo $COMMITTER "[solution]($SOLUTION_LINK)"
+echo '```'
+go test -bench . -benchmem
+echo '```'


### PR DESCRIPTION
Issue #44 here is a script for travis:
* it benchmarks new pull requests
* determines a source link
* and outputs both as markdown

Unfortunately it's not possible to make travis interact with github if a build originates from a pull request (for security reasons). For instance it's not possible to let travis comment on a github PR.

So the results can only be found in the travis build logs of a PR.
* go to a PR
* click on the travis status icon next to a commit
* in the log scroll down to the end
* unfold "after_success" (tricky to see)
* copy the markdown

This is one of my test builds:
https://travis-ci.org/shogg/practice-go/builds/432670490

This is how the markup looks like (copied from the test build):

---
shogg [solution](https://github.com/shogg/practice-go/blob/1b6154ef411969acf0c1f47ab7b9436dfeb6a90d/snowflakes/snowflakes.go)
```
goos: linux
goarch: amd64
pkg: github.com/shogg/practice-go/snowflakes
BenchmarkOverlaidTriangles-2   	 3000000	       561 ns/op	     192 B/op	       2 allocs/op
PASS
ok  	github.com/shogg/practice-go/snowflakes	2.255s
```