### PR TITLE
Faster anagram.go for small inputs

### DIFF
--- a/anagram/anagram.go
+++ b/anagram/anagram.go
@@ -2,50 +2,47 @@ package anagram
 
 import "strings"
 
-func FindAnagrams(dictionary []string, word string) (result []string) {
-	word = normalize(word)
-	if len(word) == 0 {
-		return nil
-	}
-
-	charDir := parseCharDic(word)
-	for _, value := range dictionary {
-		ww := normalize(value)
-		// ignore exact match or empty word(not anagram)
-		if ww == word || len(ww) == 0 {
+func isSubset(s, S string) bool {
+	used := make([]bool, len(S))
+OuterLoop:
+	for _, r := range s {
+		if r == ' ' {
 			continue
 		}
-
-		if compareDics(charDir, parseCharDic(ww)) {
-			result = append(result, value)
+		for i, R := range S {
+			if !used[i] && r == R {
+				used[i] = true
+				continue OuterLoop
+			}
 		}
-	}
-	return result
-}
-
-func normalize(s string) string {
-	return strings.Replace(strings.ToLower(s), " ", "", -1)
-}
-
-func parseCharDic(word string) (result map[rune]int) {
-	result = make(map[rune]int)
-	for _, char := range word {
-		result[char] = result[char] + 1
-	}
-
-	return result
-}
-
-func compareDics(dic1, dic2 map[rune]int) bool {
-	if len(dic1) != len(dic2) {
 		return false
 	}
+	return true
+}
 
-	for key, value := range dic1 {
-		if dic2[key] != value {
-			return false
+func nonEmpty(s string) bool {
+	for _, r := range s {
+		if r != ' ' {
+			return true
 		}
 	}
+	return false
+}
 
-	return true
+func isAnagram(s1, s2 string) bool {
+	s1 = strings.ToLower(s1)
+	s2 = strings.ToLower(s2)
+	return s1 != s2 && nonEmpty(s1) && nonEmpty(s2) && isSubset(s1, s2) && isSubset(s2, s1)
+}
+
+// FindAnagrams returns all the anagrams of `word` in dictionary
+func FindAnagrams(dictionary []string, word string) []string {
+	// assumes that words are short
+	result := make([]string, 0)
+	for _, w := range dictionary {
+		if isAnagram(word, w) {
+			result = append(result, w)
+		}
+	}
+	return result
 }

--- a/anagram/anagram.go
+++ b/anagram/anagram.go
@@ -2,47 +2,50 @@ package anagram
 
 import "strings"
 
-func isSubset(s, S string) bool {
-	used := make([]bool, len(S))
-OuterLoop:
-	for _, r := range s {
-		if r == ' ' {
+func FindAnagrams(dictionary []string, word string) (result []string) {
+	word = normalize(word)
+	if len(word) == 0 {
+		return nil
+	}
+
+	charDir := parseCharDic(word)
+	for _, value := range dictionary {
+		ww := normalize(value)
+		// ignore exact match or empty word(not anagram)
+		if ww == word || len(ww) == 0 {
 			continue
 		}
-		for i, R := range S {
-			if !used[i] && r == R {
-				used[i] = true
-				continue OuterLoop
-			}
-		}
-		return false
-	}
-	return true
-}
 
-func nonEmpty(s string) bool {
-	for _, r := range s {
-		if r != ' ' {
-			return true
-		}
-	}
-	return false
-}
-
-func isAnagram(s1, s2 string) bool {
-	s1 = strings.ToLower(s1)
-	s2 = strings.ToLower(s2)
-	return s1 != s2 && nonEmpty(s1) && nonEmpty(s2) && isSubset(s1, s2) && isSubset(s2, s1)
-}
-
-// FindAnagrams returns all the anagrams of `word` in dictionary
-func FindAnagrams(dictionary []string, word string) []string {
-	// assumes that words are short
-	result := make([]string, 0)
-	for _, w := range dictionary {
-		if isAnagram(word, w) {
-			result = append(result, w)
+		if compareDics(charDir, parseCharDic(ww)) {
+			result = append(result, value)
 		}
 	}
 	return result
+}
+
+func normalize(s string) string {
+	return strings.Replace(strings.ToLower(s), " ", "", -1)
+}
+
+func parseCharDic(word string) (result map[rune]int) {
+	result = make(map[rune]int)
+	for _, char := range word {
+		result[char] = result[char] + 1
+	}
+
+	return result
+}
+
+func compareDics(dic1, dic2 map[rune]int) bool {
+	if len(dic1) != len(dic2) {
+		return false
+	}
+
+	for key, value := range dic1 {
+		if dic2[key] != value {
+			return false
+		}
+	}
+
+	return true
 }

--- a/anagram/anagram_arrays.go
+++ b/anagram/anagram_arrays.go
@@ -1,0 +1,49 @@
+package anagram
+
+import "strings"
+
+func isSubset(s, S string) bool {
+	used := make([]bool, len(S))
+OuterLoop:
+	for _, r := range s {
+		if r == ' ' {
+			continue
+		}
+		for i, R := range S {
+			if !used[i] && r == R {
+				used[i] = true
+				continue OuterLoop
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func nonEmpty(s string) bool {
+	for _, r := range s {
+		if r != ' ' {
+			return true
+		}
+	}
+	return false
+}
+
+func isAnagram(s1, s2 string) bool {
+	s1 = strings.ToLower(s1)
+	s2 = strings.ToLower(s2)
+	return s1 != s2 && nonEmpty(s1) && nonEmpty(s2) && isSubset(s1, s2) && isSubset(s2, s1)
+}
+
+// FindAnagrams returns all the anagrams of `word` in dictionary.
+// Faster than a hashtable-based method for short words.
+func FindAnagrams2(dictionary []string, word string) []string {
+	// assumes that words are short
+	result := make([]string, 0)
+	for _, w := range dictionary {
+		if isAnagram(word, w) {
+			result = append(result, w)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
#### Is your solution the most efficient way to solve a problem? Why?

It's a more efficient way for small inputs because maps don't need to be initialized.

`go test -bench .` results:

```
goos: darwin
goarch: amd64
BenchmarkTestAnagrams-8             5000            224418 ns/op
PASS
ok      _/Users/admin/git/practice-go/anagram   1.154s
```

Old results: 
```
goos: darwin
goarch: amd64
BenchmarkTestAnagrams-8             2000            917811 ns/op
PASS
ok      _/Users/admin/git/practice-go/anagram   1.942s
```

#### Have you used any specific algorithm?

Nope

#### What is time and space complexity of your solution?

Time complexity is O(`dictionary_length` * `main_word_length` * `dictionary_word_length`). Space complexity is O(`dictionary_length`)