### PR TITLE
node_degree multiple solutions

### DIFF
--- a/node_degree/node_degree.go
+++ b/node_degree/node_degree.go
@@ -85,6 +85,9 @@ func DegreeStepReverse(nodes int, graph [][2]int, node int) (int, error) {
 	last := graph[lenGraph-1][1]
 
 	step := lenGraph / last
+	if step == 0 {
+		step = 1
+	}
 
 	degree := 0
 
@@ -106,11 +109,15 @@ func DegreeStepReverse(nodes int, graph [][2]int, node int) (int, error) {
 		next--
 	}
 
+	if i < 0 {
+		return degree, nil
+	}
+
 	i, _ = adjust(i, 0, graph, node)
-	for j := i + 1; graph[j][1] == node; j++ {
+	for j := i + 1; j < len(graph) && graph[j][1] == node; j++ {
 		degree++
 	}
-	for j := i; graph[j][1] == node; j-- {
+	for j := i; j >= 0 && graph[j][1] == node; j-- {
 		degree++
 	}
 	return degree, nil
@@ -121,12 +128,12 @@ func adjust(i, step int, graph [][2]int, node int) (int, int) {
 		return i, step
 	}
 	if graph[i][1] > node {
-		for graph[i][1] > node {
+		for i > 0 && graph[i][1] > node {
 			i--
 		}
 		return i, step + 1
 	}
-	for graph[i][1] < node {
+	for i < len(graph)-1 && graph[i][1] < node {
 		i++
 	}
 	return i, step - 1
@@ -137,12 +144,12 @@ func find(i int, graph [][2]int, node int) int {
 		return i
 	}
 	if graph[i][0] > node {
-		for graph[i][0] > node {
+		for i > 0 && graph[i][0] > node {
 			i--
 		}
 		return i
 	}
-	for graph[i][0] < node {
+	for i < len(graph)-1 && graph[i][0] < node {
 		i++
 	}
 	return i

--- a/node_degree/node_degree.go
+++ b/node_degree/node_degree.go
@@ -1,6 +1,219 @@
 package nodedegree
 
+import (
+	"fmt"
+	"math"
+)
+
 // Degree func
 func Degree(nodes int, graph [][2]int, node int) (int, error) {
-	return 0, nil
+	return DegreeLinearReverse(nodes, graph, node)
+}
+
+// DegreeLinear search for occurences of node
+// by interating the complete graph.
+// Access nodes within the for loop by index.
+func DegreeLinear(nodes int, graph [][2]int, node int) (int, error) {
+
+	if node > nodes {
+		return 0, fmt.Errorf("node %d not found in the graph", node)
+	}
+
+	degree := 0
+	for i := range graph {
+		if graph[i][0] == node || graph[i][1] == node {
+			degree++
+		}
+	}
+
+	return degree, nil
+}
+
+// DegreeLinearCopy search for occurences of node
+// by interating the complete graph.
+// Access nodes within the for loop by value.
+func DegreeLinearCopy(nodes int, graph [][2]int, node int) (int, error) {
+
+	if node > nodes {
+		return 0, fmt.Errorf("node %d not found in the graph", node)
+	}
+
+	degree := 0
+	for _, n := range graph {
+		if n[0] == node || n[1] == node {
+			degree++
+		}
+	}
+
+	return degree, nil
+}
+
+// DegreeLinearReverse search for occurences of node
+// by interating the sorted graph in reverse order.
+// Stop after the second end of a connection gets too small.
+func DegreeLinearReverse(nodes int, graph [][2]int, node int) (int, error) {
+
+	if node > nodes {
+		return 0, fmt.Errorf("node %d not found in the graph", node)
+	}
+
+	degree := 0
+	var i int
+	for i = len(graph) - 1; i >= 0 && graph[i][1] > node; i-- {
+		if graph[i][0] == node {
+			degree++
+		}
+	}
+
+	for j := i; j >= 0 && graph[j][1] == node; j-- {
+		degree++
+	}
+
+	return degree, nil
+}
+
+// DegreeStepReverse search for occurences of node
+// by skipping nodes in between. Step size is adjusted accordingly
+// whether the last step was too short or too long.
+func DegreeStepReverse(nodes int, graph [][2]int, node int) (int, error) {
+
+	if node > nodes {
+		return 0, fmt.Errorf("node %d not found in the graph", node)
+	}
+
+	lenGraph := len(graph)
+	last := graph[lenGraph-1][1]
+
+	step := lenGraph / last
+
+	degree := 0
+
+	next := last
+	i := lenGraph - 1
+	for ; next > node; i -= step {
+
+		i, step = adjust(i, step, graph, next)
+		if graph[i][1] != next {
+			next--
+			continue
+		}
+
+		i = find(i, graph, node)
+		if graph[i][0] == node {
+			degree++
+		}
+
+		next--
+	}
+
+	i, _ = adjust(i, 0, graph, node)
+	for j := i + 1; graph[j][1] == node; j++ {
+		degree++
+	}
+	for j := i; graph[j][1] == node; j-- {
+		degree++
+	}
+	return degree, nil
+}
+
+func adjust(i, step int, graph [][2]int, node int) (int, int) {
+	if graph[i][1] == node {
+		return i, step
+	}
+	if graph[i][1] > node {
+		for graph[i][1] > node {
+			i--
+		}
+		return i, step + 1
+	}
+	for graph[i][1] < node {
+		i++
+	}
+	return i, step - 1
+}
+
+func find(i int, graph [][2]int, node int) int {
+	if graph[i][0] == node {
+		return i
+	}
+	if graph[i][0] > node {
+		for graph[i][0] > node {
+			i--
+		}
+		return i
+	}
+	for graph[i][0] < node {
+		i++
+	}
+	return i
+}
+
+// DegreeInterpol interpolation search for occurences of node in graph.
+func DegreeInterpol(nodes int, graph [][2]int, node int) (int, error) {
+
+	if node > nodes {
+		return 0, fmt.Errorf("node %d not found in the graph", node)
+	}
+
+	// shift factor needed to convert nodes to integers
+	log2 := uint(math.Log2(float64(nodes))) + 1
+
+	// search on the first end of connections
+	end := len(graph)
+	degree := 0
+	for n := graph[len(graph)-1][1]; n > node; n-- {
+		i := interpolSearch(graph[:end], [2]int{node, n}, log2)
+		if graph[i][0] == node {
+			degree++
+		}
+		end = i
+	}
+
+	// search on the second end of connections
+	i := interpolSearch(graph, [2]int{node - 1, node}, log2)
+	for j := i + 1; j < len(graph) && graph[j][1] == node; j++ {
+		degree++
+	}
+	for j := i; j >= 0 && graph[j][1] == node; j-- {
+		degree++
+	}
+
+	return degree, nil
+}
+
+// num convert nodes to integers.
+func num(n [2]int, log2 uint) int64 {
+	return int64(n[1]<<log2) + int64(n[0])
+}
+
+// interpolSearch search for index of node in graph by linear interpolation.
+// Time complexity O(log log n).
+func interpolSearch(graph [][2]int, node [2]int, log2 uint) int {
+
+	l := 0
+	r := len(graph) - 1
+	n := num(node, log2)
+
+	x := r
+	for r != l {
+		gl := num(graph[l], log2)
+		gr := num(graph[r], log2)
+		if n < gl || n > gr {
+			return x
+		}
+		xf := float64(n-gl) / float64(gr-gl) * float64(r-l)
+		x = l + int(xf)
+		if graph[x] == node {
+			break
+		}
+		if num(graph[x], log2) < n {
+			x++
+			l = x
+			continue
+		}
+		x--
+		r = x
+	}
+
+	return x
 }


### PR DESCRIPTION
I tested five solutions:
- DegreeLinear
  - iterate the whole graph
  - access nodes by index
- DegreeLinearCopy
  - iterate the whole graph
  - access nodes by value (loop variable)
- DegreeLinearReverse
  - iterate backwards
  - until nodes on the second end of a connection get too small
- DegreeStepReverse
  - iterate backwards
  - skip multiple nodes in between
  - search for node in the surrounding
  - adjust the step size for the next iteration
- DegreeInterpol
  - use interpolation search
  - time complexity O(log log n) to find a single occurrence

```
BenchmarkBig/Linear-8         	20000000	        63.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBig/LinearCopy-8     	20000000	       100 ns/op	       0 B/op	       0 allocs/op
BenchmarkBig/LinearReverse-8  	30000000	        51.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBig/StepReverse-8    	20000000	       105 ns/op	       0 B/op	       0 allocs/op
BenchmarkBig/Interpol-8       	 3000000	       456 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/shogg/practice-go/node_degree	9.381s
Success: Benchmarks passed.
```
benchmark results for bigGraph:
  - DegreeLinearReverse is the fasted
  - DegreeLinear is faster than DegreeLinearCopy
  - DegreeStepReverse computation overhead makes it slow for small data sets.
  - DegreeInterpol overhead makes it even slower

I added another benchmark with a much bigger graph (hugeGraph). The size is adjustable by parameters in source code. Currently it contains 100,000,000 nodes.

```
BenchmarkHuge/Linear-8         	      20	  61905910 ns/op	       0 B/op	       0 allocs/op
BenchmarkHuge/LinearCopy-8     	      20	  68374685 ns/op	       0 B/op	       0 allocs/op
BenchmarkHuge/LinearReverse-8  	      30	  48533443 ns/op	       0 B/op	       0 allocs/op
BenchmarkHuge/StepReverse-8    	     100	  17372945 ns/op	       0 B/op	       0 allocs/op
BenchmarkHuge/Interpol-8       	      50	  37552458 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/shogg/practice-go/node_degree	16.913s
Success: Benchmarks passed.
```
benchmark results for hugeGraph:
  - DegreeStepReverse is now the fastest algorithm
  - DegreeInterpol can be dropped; usually the slowest and never the fastest algorithm

conclusion
 - DegreeLinearReverse best for small graphs (< 100 nodes)
 - DegreeStepReverse best for bigger graphs  (> 100 nodes)