### PR TITLE
18x speed boost to secretmessage

### DIFF
--- a/secretmessage/secretmessage.go
+++ b/secretmessage/secretmessage.go
@@ -5,21 +5,25 @@ import "sort"
 // Decode func
 func Decode(encoded string) string {
 	// count: size 27 for main case of alpha+_
-	counts := make(map[rune]int, 27)
+	counts := make([]int, 27)
 	for _, r := range encoded {
-		counts[r]++
+		if r == '_' {
+			counts[26]++
+		} else {
+			counts[r-'a']++
+		}
 	}
 	// only get runes with count >= counts[_]
 	// cap 26 for base case of alpha chars
 	runes := make([]rune, 0, 26)
 	for k, v := range counts {
-		if k != '_' && v >= counts['_'] {
-			runes = append(runes, k)
+		if k != 26 && v >= counts[26] {
+			runes = append(runes, rune('a'+k))
 		}
 	}
 	// sort runes by count desc
 	sort.Slice(runes, func(i, j int) bool {
-		return counts[runes[i]] > counts[runes[j]]
+		return counts[runes[i]-'a'] > counts[runes[j]-'a']
 	})
 	// return string
 	return string(runes)


### PR DESCRIPTION
before:
```
$ go test -bench .
goos: linux
goarch: amd64
BenchmarkDecode-12         21541             55585 ns/op
```
after
```
BenchmarkDecode-12        389108              2950 ns/op
```

#### Is your solution the most efficient way to solve a problem? Why?
This is a tweak to the existing solution to replace a `map` with a `slice`, which is much faster.
This does result in the implementation being much more tightly tied to just the lowercase English alphabet than it was before, however.
#### Have you used any specific algorithm?
Same as before
#### What is time and space complexity of your solution?
Same as before